### PR TITLE
CCF-5620: cortex skill generate template for node8 is incorrect

### DIFF
--- a/generators/skill/templates/function/node8/build-function.sh
+++ b/generators/skill/templates/function/node8/build-function.sh
@@ -8,7 +8,7 @@ fi
 mkdir -p $SCRIPT_DIR/build/stage
 
 # copy source to a staging folder
-cp -r $SCRIPT_DIR/package.json $SCRIPT_DIR/src/ $SCRIPT_DIR/build/stage
+cp -r $SCRIPT_DIR/package.json $SCRIPT_DIR/src/index.js $SCRIPT_DIR/build/stage
 # Install node dependencies
 cd $SCRIPT_DIR/build/stage
 npm install --only=production

--- a/generators/skill/templates/function/node8/package.json
+++ b/generators/skill/templates/function/node8/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Update this description -- <%= projectName %> <%= functionName %>",
   "license": "UNLICENSED",
-  "main": "src/index.js",
+  "main": "./index.js",
   "dependencies" : {
     "left-pad" : "1.1.3"
   }

--- a/generators/skill/templates/function/node8/src/index.js
+++ b/generators/skill/templates/function/node8/src/index.js
@@ -1,13 +1,9 @@
 
 function main(args) {
     const payload = args.payload || {};
-    return { payload: <%= functionName %>(payload) };
-}
-
-function <%= functionName %>(payload) {
-    const leftPad = require("left-pad")
+    const leftPad = require("left-pad");
     const text = payload.text || "(silence)";
-    return { text: leftPad(text, 30, ".") };
+    return { payload: { text: leftPad(text, 30, ".") } };
 }
 
 exports.main = main;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c12e/generator-cortex",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Generates a development project for Cortex constructs like actions and skills",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
 - removed extra function in `index.js` to guard against incorrect function name (`-` is an invalid character)
 - copy only `src/index.js` to stage directory before building zipfile
 - updated node8 function `package.json` in reference different main file location
 - bump generator package version