### PR TITLE
Ccf 8968 py3 func unittest

### DIFF
--- a/generators/skill/templates/function/python3/DEVELOPER.md
+++ b/generators/skill/templates/function/python3/DEVELOPER.md
@@ -23,5 +23,12 @@ source activate cortex-function
 
 Install Python dependencies:
 ```
-pip install -r requirements.txt
+pip install -r src/requirements.txt
+```
+
+## Unit tests
+
+Run unit tests:
+```
+python test/test.py
 ```

--- a/generators/skill/templates/function/python3/requirements.txt
+++ b/generators/skill/templates/function/python3/requirements.txt
@@ -1,1 +1,0 @@
-cortex-client

--- a/generators/skill/templates/function/python3/src/requirements.txt
+++ b/generators/skill/templates/function/python3/src/requirements.txt
@@ -1,0 +1,1 @@
+cortex-client

--- a/generators/skill/templates/function/python3/test/test.py
+++ b/generators/skill/templates/function/python3/test/test.py
@@ -1,9 +1,12 @@
-import unittest, json
-import ../__main__
+import unittest, json, sys, os
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from src.__main__ import main
+
 class TestFunction(unittest.TestCase):
 
     def test_req(self):
-        with open('test_req.json') as data_file:
+        test_req = os.path.join(os.path.dirname(__file__), "unit_test_req.json")
+        with open(test_req) as data_file:
             data = json.load(data_file)
             print(main(data))
 

--- a/generators/skill/templates/function/python3/test/unit_test_req.json
+++ b/generators/skill/templates/function/python3/test/unit_test_req.json
@@ -1,0 +1,13 @@
+{
+  "instanceId": "test_instance_id",
+  "sessionId": "test_session_id",
+  "channelId": "test_channel_id",
+  "apiEndpoint": "https://api.cortex.insights.ai",
+  "token": "test_token",
+  "properties": {
+    "lang": "it"
+  },
+  "payload": {
+    "text": "Jenna"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@c12e/generator-cortex",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1313,9 +1313,9 @@
       }
     },
     "joi": {
-      "version": "13.1.2",
-      "resolved": "https://cognitivescale.jfrog.io/cognitivescale/api/npm/npm-repo/joi/-/joi-13.1.2.tgz",
-      "integrity": "sha1-stsmAyPMf5Gfr6UeCeInW9CJqX4=",
+      "version": "13.7.0",
+      "resolved": "https://cognitivescale.jfrog.io/cognitivescale/api/npm/npm-repo/joi/-/joi-13.7.0.tgz",
+      "integrity": "sha1-z9hev+Z+ihkAQyQAtNA7vZP7h58=",
       "requires": {
         "hoek": "5.x.x",
         "isemail": "3.x.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@c12e/generator-cortex",
-  "version": "0.3.12",
+  "version": "0.3.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c12e/generator-cortex",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "description": "Generates a development project for Cortex constructs like actions and skills",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Fix the unit test code generated for python 3.

@vadan-cs  I ended up adding `..` to the path rather than using a module because it gave more independence to invoke from different directories and I didnt have to work out how to create/name the module. Let me know if you think we need to do differently.

I created a separate `unit_test_req.json` because I didnt want people using made-up ID fields in requests that actually go to Cortex actions service.  Of course, if someone created unit tests for a function that then made calls to Cortex, this could still happen, and they'd have to figure out how to pass a valid token etc or they'd have to create a mock for the Cortex client. So we've got a way to go before it would feel like we're really helping people do unit tests of functions.... 