### PR TITLE
Add scripts for linux

### DIFF
--- a/generators/connections/templates/scripts/linux/deploy-connection.sh
+++ b/generators/connections/templates/scripts/linux/deploy-connection.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Deploy our skill to Cortex
+cortex connections save --yaml $SCRIPT_DIR/connection.yaml

--- a/generators/datasets/templates/scripts/linux/deploy-dataset.sh
+++ b/generators/datasets/templates/scripts/linux/deploy-dataset.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Deploy our skill to Cortex
+cortex datasets save --yaml $SCRIPT_DIR/dataset.yaml

--- a/generators/job/templates/function/scripts/linux/deploy-job.sh
+++ b/generators/job/templates/function/scripts/linux/deploy-job.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+echo $SCRIPT_DIR
+# Deploy our job to Cortex
+cortex jobs save --yaml job.yaml

--- a/generators/skill/templates/function/scripts/common/linux/build-function.sh
+++ b/generators/skill/templates/function/scripts/common/linux/build-function.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -d $SCRIPT_DIR/build ]; then
+    rm -rf $SCRIPT_DIR/build
+fi
+
+mkdir $SCRIPT_DIR/build
+zip -rjq $SCRIPT_DIR/build/function.zip $SCRIPT_DIR/src

--- a/generators/skill/templates/function/scripts/common/linux/deploy-function.sh
+++ b/generators/skill/templates/function/scripts/common/linux/deploy-function.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Run the build
+${SCRIPT_DIR}/build-function.sh
+
+# Deploy our function to Cortex
+cortex actions deploy <%= projectPrefix %><%= functionName %> --code "${SCRIPT_DIR}/build/function.zip" --kind <%= deploymentType %>

--- a/generators/skill/templates/function/scripts/common/linux/deploy-skill.sh
+++ b/generators/skill/templates/function/scripts/common/linux/deploy-skill.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Deploy our skill to Cortex
+cortex skills save --yaml skill.yaml

--- a/generators/skill/templates/function/scripts/common/linux/test-function.sh
+++ b/generators/skill/templates/function/scripts/common/linux/test-function.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cortex actions invoke <%= projectPrefix %><%= functionName %> --params-file "${SCRIPT_DIR}/test/test_req.json"

--- a/generators/skill/templates/function/scripts/node8/linux/build-function.sh
+++ b/generators/skill/templates/function/scripts/node8/linux/build-function.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -e
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ -d $SCRIPT_DIR/build ]; then
+    rm -rf $SCRIPT_DIR/build
+fi
+mkdir -p $SCRIPT_DIR/build/stage
+
+# copy source to a staging folder
+cp -r $SCRIPT_DIR/package.json $SCRIPT_DIR/src/index.js $SCRIPT_DIR/build/stage
+# Install node dependencies
+cd $SCRIPT_DIR/build/stage
+npm install --only=production
+zip -rq ../function.zip .
+cd $SCRIPT_DIR

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@c12e/generator-cortex",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c12e/generator-cortex",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Generates a development project for Cortex constructs like actions and skills",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
Turns out that the integration tests run on linux, so adding platform-specific scripts broke the tests.

I've added a copy of the `darwin` scripts to provide support for 'linux' and confirmed this works by running the tests in the api test container on my laptop.

However, that means running the tests dont actually give us confidence that the generates will work on either of the actually-supported platforms (Mac & Windows). I _could_ instead change the code so that it uses `darwin` scripts if it can't find one for the specified platform, but that feels a bit unclean. I guess the tests as-is give us some confidence for Mac until the next time there's a generator update that impacts the scripts...

Thoughts/opinions?