### PR TITLE
Ccf 9376 modify advanced jdbc

### DIFF
--- a/generators/connections/index.js
+++ b/generators/connections/index.js
@@ -22,8 +22,8 @@ const connTypes = [
     { 'display': 'Postgres SQL', 'name': 'postgresql' },
     { 'display': 'Microsoft SQL Server', 'name': 'mssql' },
     { 'display': 'MySQL', 'name': 'mysql' },
-    { 'display': 'Generic JDBC Connection', 'name': 'generic_jdbc' },
-    { 'display': 'Advanced JDBC Connection', 'name': 'advanced_jdbc' },
+    { 'display': 'Generic JDBC Connection', 'name': 'generic_jdbc', 'contentType' : 'Basic' },
+    { 'display': 'Advanced JDBC Connection', 'name': 'generic_jdbc' , 'contentType': 'Advanced'},
     { 'display': 'Hive', 'name': 'hive' } // Fix me dont have one for hive yet
 ];
 
@@ -39,7 +39,9 @@ function displayStrings(table) {
 function lookupNameByDisplay(table, lookup) {
     return table.filter(entry => entry.display === lookup)[0].name
 }
-
+function lookupContentType(table, lookup) {
+    return table.filter(entry => entry.display === lookup)[0].contentType
+}
 const Generator = require('yeoman-generator');
 
 module.exports = class extends Generator {
@@ -72,7 +74,7 @@ module.exports = class extends Generator {
       },
       {
         when: function (response) {
-            return lookupNameByDisplay(connTypes, response.connType) !== 'advanced_jdbc';
+            return lookupContentType(connTypes, response.connType) !== 'Advanced';
         },
         type    : 'input',
         name    : 'uri',
@@ -80,7 +82,7 @@ module.exports = class extends Generator {
       },
       {
         when: function (response) {
-            return lookupNameByDisplay(connTypes, response.connType) === 'advanced_jdbc';
+            return lookupContentType(connTypes, response.connType) === 'Advanced';
         },
         type    : 'input',
         name    : 'plugin_jar',
@@ -93,6 +95,11 @@ module.exports = class extends Generator {
         this.options.connTitle     = answers.connTitle.trim();
         this.options.uri           = answers.uri;
         this.options.plugin_jar    = answers.plugin_jar;
+        this.options.contentType   = lookupContentType(connTypes, this.options.connType);
+
+        if(this.options.contentType){
+            this.options.contentType = `contentType: ${this.options.contentType}`;
+        }
       });
     }
 
@@ -101,8 +108,9 @@ module.exports = class extends Generator {
 
         let templateName = connTypeShort;
         this.options.connTypeShort = connTypeShort;
-
-        if (isJdbc.includes(connTypeShort)) {
+        if(lookupContentType(connTypes, this.options.connType) === 'Advanced') {
+            templateName = 'advanced_jdbc';
+        } else if (isJdbc.includes(connTypeShort)) {
             this.options.classname = `org.${connTypeShort}.Driver`;
             templateName = 'jdbc';
         }

--- a/generators/connections/templates/template/advanced_jdbc/connection.yaml
+++ b/generators/connections/templates/template/advanced_jdbc/connection.yaml
@@ -2,6 +2,7 @@ name: <%= connName %>
 title: <%= connTitle %>
 description: Update this description
 connectionType: <%= connTypeShort %>
+<%= contentType %>
 allowWrite: true
 params:
   - name: "plugin_jar"

--- a/generators/connections/templates/template/jdbc/connection.yaml
+++ b/generators/connections/templates/template/jdbc/connection.yaml
@@ -2,6 +2,7 @@ name: <%= connName %>
 title: <%= connTitle %>
 description: Update this description
 connectionType: <%= connTypeShort %>
+<%= contentType %>
 allowWrite: true
 params:
   - name: uri

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@c12e/generator-cortex",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "description": "Generates a development project for Cortex constructs like actions and skills",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
advanced_jdbc connectionType has been removed.
generic_jdbc will have a contentType field which will be either 'Basic' or 'Advanced'
switching templates of the contentType field now.